### PR TITLE
chore: disable node polyfills in Next.js config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,0 @@
-/** @type {import('next').NextConfig} */
-const nextConfig = { eslint: { ignoreDuringBuilds: true } };
-module.exports = nextConfig;

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,3 +1,21 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = { eslint: { ignoreDuringBuilds: true } };
+const nextConfig = {
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
+  webpack: (config, { isServer }) => {
+    if (!isServer) {
+      config.resolve.fallback = {
+        ...config.resolve.fallback,
+        fs: false,
+        path: false,
+        os: false,
+        net: false,
+        tls: false,
+      };
+    }
+    return config;
+  },
+};
+
 export default nextConfig;


### PR DESCRIPTION
## Summary
- disable Node.js core module polyfills in the Next.js webpack config
- remove duplicate `next.config.js` to avoid conflicting settings

## Testing
- `pnpm dev`
- `pnpm test:unit`
- `pnpm dlx vercel@latest build` *(fails: GET https://registry.npmjs.org/vercel: Forbidden - 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ff49160c8325b03484b94517f5a2