### PR TITLE
chore: enforce server-only on db and auth modules

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,3 +1,4 @@
+import 'server-only';
 import NextAuth from "next-auth";
 import Email from "next-auth/providers/email";
 import { DrizzleAdapter } from "@auth/drizzle-adapter";

--- a/lib/auth/index.ts
+++ b/lib/auth/index.ts
@@ -1,3 +1,4 @@
+import 'server-only';
 import NextAuth from "next-auth";
 import { DrizzleAdapter } from "@auth/drizzle-adapter";
 import { db } from "../db";

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,4 +1,5 @@
 // lib/db.ts
+import 'server-only';
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
 import * as schema from "@/lib/db/schema";


### PR DESCRIPTION
## Summary
- mark db access file as server-only
- mark auth modules as server-only

## Testing
- `pnpm lint` *(fails: Invalid Options - Unknown options: useEslintrc, extensions, resolvePluginsRelativeTo, rulePaths, ignorePath, reportUnusedDisableDirectives)*
- `pnpm test:unit` *(fails: Command failed with exit code 130)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ff4b40ec8325ba8f27d19b5ea5d7