### PR TITLE
refactor: split safe action into server and client

### DIFF
--- a/components/groups/endpoints/create-form.tsx
+++ b/components/groups/endpoints/create-form.tsx
@@ -38,7 +38,7 @@ import {
 } from "@/components/ui/select";
 
 import { useAction } from "next-safe-action/hooks";
-import { parseActionError } from "@/lib/data/safe-action";
+import { parseActionError } from "@/lib/data/safe-action.client";
 import { createEndpoint } from "@/lib/data/endpoints";
 
 type DomainValues = z.infer<typeof formSchema>;

--- a/components/groups/endpoints/edit-form.tsx
+++ b/components/groups/endpoints/edit-form.tsx
@@ -38,7 +38,7 @@ import {
 import { Endpoint } from "@/lib/db";
 
 import { useAction } from "next-safe-action/hooks";
-import { parseActionError } from "@/lib/data/safe-action";
+import { parseActionError } from "@/lib/data/safe-action.client";
 import { updateEndpoint } from "@/lib/data/endpoints";
 
 type DomainValues = z.infer<typeof formSchema>;

--- a/components/groups/endpoints/options-dropdown.tsx
+++ b/components/groups/endpoints/options-dropdown.tsx
@@ -28,7 +28,7 @@ import {
 } from "@/lib/data/endpoints";
 
 import { useAction } from "next-safe-action/hooks";
-import { parseActionError } from "@/lib/data/safe-action";
+import { parseActionError } from "@/lib/data/safe-action.client";
 import { toast } from "sonner";
 
 export default function OptionsDropdown({

--- a/components/groups/leads/options-dropdown.tsx
+++ b/components/groups/leads/options-dropdown.tsx
@@ -22,7 +22,7 @@ import { useState } from "react";
 
 import { deleteLead } from "@/lib/data/leads";
 import { useAction } from "next-safe-action/hooks";
-import { parseActionError } from "@/lib/data/safe-action";
+import { parseActionError } from "@/lib/data/safe-action.client";
 import { toast } from "sonner";
 
 export default function OptionsDropdown({ id }: { id: string }) {

--- a/components/groups/logs/options-dropdown.tsx
+++ b/components/groups/logs/options-dropdown.tsx
@@ -22,7 +22,7 @@ import { useState } from "react";
 
 import { deleteLog } from "@/lib/data/logs";
 import { useAction } from "next-safe-action/hooks";
-import { parseActionError } from "@/lib/data/safe-action";
+import { parseActionError } from "@/lib/data/safe-action.client";
 import { toast } from "sonner";
 
 export default function OptionsDropdown({ id }: { id: string }) {

--- a/lib/data/dashboard.ts
+++ b/lib/data/dashboard.ts
@@ -2,7 +2,7 @@
 
 import { sql } from "drizzle-orm";
 import { db } from "../db";
-import { authenticatedAction } from "./safe-action";
+import { authenticatedAction } from "./safe-action.server";
 
 /**
  * Get lead and error counts in proper format for shadcn/ui charts

--- a/lib/data/endpoints.ts
+++ b/lib/data/endpoints.ts
@@ -5,7 +5,7 @@ import { db, Endpoint } from "../db";
 import { endpoints } from "../db/schema";
 import { eq, desc, and } from "drizzle-orm";
 import { getErrorMessage } from "@/lib/helpers/error-message";
-import { authenticatedAction } from "./safe-action";
+import { authenticatedAction } from "./safe-action.server";
 import { z } from "zod";
 import {
   createEndpointFormSchema,

--- a/lib/data/leads.ts
+++ b/lib/data/leads.ts
@@ -4,7 +4,7 @@ import { leads, endpoints } from "../db/schema";
 import { eq, desc, and } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
 import { db } from "../db";
-import { authenticatedAction } from "./safe-action";
+import { authenticatedAction } from "./safe-action.server";
 import { z } from "zod";
 
 /**

--- a/lib/data/logs.ts
+++ b/lib/data/logs.ts
@@ -4,7 +4,7 @@ import { logs, endpoints } from "../db/schema";
 import { eq, desc } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
 import { db } from "../db";
-import { authenticatedAction } from "./safe-action";
+import { authenticatedAction } from "./safe-action.server";
 import { z } from "zod";
 
 /**

--- a/lib/data/safe-action.client.ts
+++ b/lib/data/safe-action.client.ts
@@ -1,43 +1,3 @@
-import {
-  createSafeActionClient,
-  DEFAULT_SERVER_ERROR_MESSAGE,
-} from "next-safe-action";
-import { auth } from "../auth";
-
-class ActionError extends Error {}
-
-/**
- * Creates a client of next-safe-action to use in server actions
- */
-export const actionClient = createSafeActionClient({
-  handleServerError(e) {
-    if (e instanceof ActionError) {
-      return e.message;
-    }
-
-    return DEFAULT_SERVER_ERROR_MESSAGE;
-  },
-});
-
-/**
- * Creates an authenticated action
- *
- * Passes the userId to the next function
- *
- * @returns {Promise<void>} A promise that resolves when the action is executed.
- * @throws {Error} If the user is not authenticated or the user ID is not available.
- */
-export const authenticatedAction = actionClient.use(async ({ next }) => {
-  const session = await auth();
-  const userId = session?.user.id;
-
-  if (!session || !userId) {
-    throw new Error("Not authenticated");
-  }
-
-  return next({ ctx: { userId } });
-});
-
 /**
  * Parses the action error object and returns a formatted error message.
  *
@@ -96,3 +56,4 @@ export const parseActionError = (error: {
 
   return errorMessage.trim();
 };
+

--- a/lib/data/safe-action.server.ts
+++ b/lib/data/safe-action.server.ts
@@ -1,0 +1,42 @@
+'use server';
+
+import {
+  createSafeActionClient,
+  DEFAULT_SERVER_ERROR_MESSAGE,
+} from "next-safe-action";
+import { auth } from "../auth";
+
+class ActionError extends Error {}
+
+/**
+ * Creates a client of next-safe-action to use in server actions
+ */
+export const actionClient = createSafeActionClient({
+  handleServerError(e) {
+    if (e instanceof ActionError) {
+      return e.message;
+    }
+
+    return DEFAULT_SERVER_ERROR_MESSAGE;
+  },
+});
+
+/**
+ * Creates an authenticated action
+ *
+ * Passes the userId to the next function
+ *
+ * @returns {Promise<void>} A promise that resolves when the action is executed.
+ * @throws {Error} If the user is not authenticated or the user ID is not available.
+ */
+export const authenticatedAction = actionClient.use(async ({ next }) => {
+  const session = await auth();
+  const userId = session?.user.id;
+
+  if (!session || !userId) {
+    throw new Error("Not authenticated");
+  }
+
+  return next({ ctx: { userId } });
+});
+

--- a/lib/data/stripe.ts
+++ b/lib/data/stripe.ts
@@ -2,7 +2,7 @@
 
 import { Stripe } from "stripe";
 import { headers } from "next/headers";
-import { authenticatedAction } from "./safe-action";
+import { authenticatedAction } from "./safe-action.server";
 import { z } from "zod";
 import { db } from "../db";
 import { users } from "../db/schema";

--- a/lib/data/users.ts
+++ b/lib/data/users.ts
@@ -3,7 +3,7 @@
 import { db } from "../db";
 import { users, endpoints } from "../db/schema";
 import { eq, sql } from "drizzle-orm";
-import { authenticatedAction } from "./safe-action";
+import { authenticatedAction } from "./safe-action.server";
 
 /**
  * Increments the lead count for a user


### PR DESCRIPTION
## Summary
- add server-only safe action helpers exporting `actionClient` and `authenticatedAction`
- move `parseActionError` to client-safe module
- update server actions and client components to import new modules

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid Options: Unknown options: useEslintrc, extensions, resolvePluginsRelativeTo, rulePaths, ignorePath, reportUnusedDisableDirectives)*
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68b4ff4c3a988325a05e4fa0d88a34fb