### PR TITLE
refactor: use type-only db imports in client components

### DIFF
--- a/components/groups/endpoints/columns.tsx
+++ b/components/groups/endpoints/columns.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Endpoint } from "@/lib/db";
+import type { Endpoint } from "@/lib/db/types";
 import { ColumnDef } from "@tanstack/react-table";
 import { DataTableColumnHeader } from "@/components/data-table/header";
 import { Badge } from "@/components/ui/badge";

--- a/components/groups/endpoints/edit-form.tsx
+++ b/components/groups/endpoints/edit-form.tsx
@@ -35,7 +35,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Endpoint } from "@/lib/db";
+import type { Endpoint } from "@/lib/db/types";
 
 import { useAction } from "next-safe-action/hooks";
 import { parseActionError } from "@/lib/data/safe-action";

--- a/components/groups/leads/columns.tsx
+++ b/components/groups/leads/columns.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Lead } from "@/lib/db";
+import type { Lead } from "@/lib/db/types";
 import { ColumnDef } from "@tanstack/react-table";
 import { Button } from "@/components/ui/button";
 import { DataTableColumnHeader } from "@/components/data-table/header";

--- a/components/groups/leads/data-table-toolbar.tsx
+++ b/components/groups/leads/data-table-toolbar.tsx
@@ -8,7 +8,7 @@ import { Input } from "@/components/ui/input";
 import { DataTableViewOptions } from "@/components/data-table/data-table-view-options";
 import { DataTableFacetedFilter } from "@/components/data-table/data-table-faceted-filter";
 
-import { Endpoint } from "@/lib/db";
+import type { Endpoint } from "@/lib/db/types";
 
 interface DataTableToolbarProps<TData> {
   table: Table<TData>;

--- a/components/groups/leads/data-table.tsx
+++ b/components/groups/leads/data-table.tsx
@@ -28,7 +28,7 @@ import {
 
 import { DataTablePagination } from "@/components/data-table/pagination";
 import { DataTableToolbar } from "./data-table-toolbar";
-import { Endpoint } from "@/lib/db";
+import type { Endpoint } from "@/lib/db/types";
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];

--- a/components/groups/logs/data-table-toolbar.tsx
+++ b/components/groups/logs/data-table-toolbar.tsx
@@ -8,7 +8,7 @@ import { Input } from "@/components/ui/input";
 import { DataTableViewOptions } from "@/components/data-table/data-table-view-options";
 import { DataTableFacetedFilter } from "@/components/data-table/data-table-faceted-filter";
 import { CircleCheck, CircleX, Webhook, CodeXml } from "lucide-react";
-import { Endpoint } from "@/lib/db";
+import type { Endpoint } from "@/lib/db/types";
 
 interface DataTableToolbarProps<TData> {
   table: Table<TData>;

--- a/components/groups/logs/data-table.tsx
+++ b/components/groups/logs/data-table.tsx
@@ -28,7 +28,7 @@ import {
 
 import { DataTablePagination } from "@/components/data-table/pagination";
 import { DataTableToolbar } from "./data-table-toolbar";
-import { Endpoint } from "@/lib/db";
+import type { Endpoint } from "@/lib/db/types";
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];

--- a/components/parts/export-csv.tsx
+++ b/components/parts/export-csv.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Lead } from "@/lib/db";
+import type { Lead } from "@/lib/db/types";
 import { Button } from "../ui/button";
 import { parse } from "json2csv";
 import { toast } from "sonner";

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -8,6 +8,7 @@ import {
   boolean,
   jsonb,
 } from "drizzle-orm/pg-core";
+import type { InferSelectModel } from "drizzle-orm";
 import type { AdapterAccount } from "@auth/core/adapters";
 import { init } from "@paralleldrive/cuid2";
 
@@ -142,3 +143,6 @@ export const logs = pgTable("log", {
   message: jsonb("message").$type<Record<string, any> | unknown>().notNull(),
   createdAt: timestamp("createdAt", { mode: "date" }).notNull(),
 });
+
+export type Endpoint = InferSelectModel<typeof endpoints>;
+export type Lead = InferSelectModel<typeof leads>;

--- a/lib/db/types.ts
+++ b/lib/db/types.ts
@@ -1,0 +1,1 @@
+export type { Endpoint, Lead } from "./schema";


### PR DESCRIPTION
## Summary
- add `lib/db/types.ts` to re-export `Endpoint` and `Lead` models
- export `Endpoint` and `Lead` type aliases from `schema.ts`
- update client components to import types via `import type` so no DB runtime code ships to browser

## Testing
- `pnpm test:unit --run`
- `pnpm lint` *(fails: Invalid Options: Unknown options: useEslintrc, extensions, resolvePluginsRelativeTo, rulePaths, ignorePath, reportUnusedDisableDirectives)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ff4e86908325ad226034925df66a