### PR TITLE
chore: add client directives

### DIFF
--- a/components/groups/endpoints/options-dropdown.tsx
+++ b/components/groups/endpoints/options-dropdown.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   DropdownMenu,
   DropdownMenuContent,

--- a/components/groups/leads/options-dropdown.tsx
+++ b/components/groups/leads/options-dropdown.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   DropdownMenu,
   DropdownMenuContent,

--- a/components/groups/logs/options-dropdown.tsx
+++ b/components/groups/logs/options-dropdown.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   DropdownMenu,
   DropdownMenuContent,

--- a/components/ui/form.tsx
+++ b/components/ui/form.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import * as React from "react"
 import * as LabelPrimitive from "@radix-ui/react-label"
 import { Slot } from "@radix-ui/react-slot"


### PR DESCRIPTION
## Summary
- add "use client" directive to form and options dropdown components

## Testing
- `npm run lint` *(fails: Unknown options: useEslintrc, extensions, resolvePluginsRelativeTo, rulePaths, ignorePath, reportUnusedDisableDirectives)*
- `npm run test:unit -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b4ff4f4d8c832585a32e1171a1d49e