### PR TITLE
refactor: isolate db types and runtime

### DIFF
--- a/components/groups/endpoints/columns.tsx
+++ b/components/groups/endpoints/columns.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Endpoint } from "@/lib/db";
+import type { Endpoint } from "@/lib/db/index";
 import { ColumnDef } from "@tanstack/react-table";
 import { DataTableColumnHeader } from "@/components/data-table/header";
 import { Badge } from "@/components/ui/badge";

--- a/components/groups/endpoints/edit-form.tsx
+++ b/components/groups/endpoints/edit-form.tsx
@@ -35,7 +35,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Endpoint } from "@/lib/db";
+import type { Endpoint } from "@/lib/db/index";
 
 import { useAction } from "next-safe-action/hooks";
 import { parseActionError } from "@/lib/data/safe-action";

--- a/components/groups/leads/columns.tsx
+++ b/components/groups/leads/columns.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Lead } from "@/lib/db";
+import type { Lead } from "@/lib/db/index";
 import { ColumnDef } from "@tanstack/react-table";
 import { Button } from "@/components/ui/button";
 import { DataTableColumnHeader } from "@/components/data-table/header";

--- a/components/groups/leads/data-table-toolbar.tsx
+++ b/components/groups/leads/data-table-toolbar.tsx
@@ -8,7 +8,7 @@ import { Input } from "@/components/ui/input";
 import { DataTableViewOptions } from "@/components/data-table/data-table-view-options";
 import { DataTableFacetedFilter } from "@/components/data-table/data-table-faceted-filter";
 
-import { Endpoint } from "@/lib/db";
+import type { Endpoint } from "@/lib/db/index";
 
 interface DataTableToolbarProps<TData> {
   table: Table<TData>;

--- a/components/groups/leads/data-table.tsx
+++ b/components/groups/leads/data-table.tsx
@@ -28,7 +28,7 @@ import {
 
 import { DataTablePagination } from "@/components/data-table/pagination";
 import { DataTableToolbar } from "./data-table-toolbar";
-import { Endpoint } from "@/lib/db";
+import type { Endpoint } from "@/lib/db/index";
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];

--- a/components/groups/logs/data-table-toolbar.tsx
+++ b/components/groups/logs/data-table-toolbar.tsx
@@ -8,7 +8,7 @@ import { Input } from "@/components/ui/input";
 import { DataTableViewOptions } from "@/components/data-table/data-table-view-options";
 import { DataTableFacetedFilter } from "@/components/data-table/data-table-faceted-filter";
 import { CircleCheck, CircleX, Webhook, CodeXml } from "lucide-react";
-import { Endpoint } from "@/lib/db";
+import type { Endpoint } from "@/lib/db/index";
 
 interface DataTableToolbarProps<TData> {
   table: Table<TData>;

--- a/components/groups/logs/data-table.tsx
+++ b/components/groups/logs/data-table.tsx
@@ -28,7 +28,7 @@ import {
 
 import { DataTablePagination } from "@/components/data-table/pagination";
 import { DataTableToolbar } from "./data-table-toolbar";
-import { Endpoint } from "@/lib/db";
+import type { Endpoint } from "@/lib/db/index";
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];

--- a/components/parts/export-csv.tsx
+++ b/components/parts/export-csv.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Lead } from "@/lib/db";
+import type { Lead } from "@/lib/db/index";
 import { Button } from "../ui/button";
 import { parse } from "json2csv";
 import { toast } from "sonner";

--- a/lib/data/endpoints.ts
+++ b/lib/data/endpoints.ts
@@ -1,7 +1,8 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { db, Endpoint } from "../db";
+import { db } from "../db";
+import type { Endpoint } from "../db/index";
 import { endpoints } from "../db/schema";
 import { eq, desc, and } from "drizzle-orm";
 import { getErrorMessage } from "@/lib/helpers/error-message";

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,4 +1,4 @@
-// lib/db.ts
+import "server-only";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
 import * as schema from "@/lib/db/schema";

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -1,6 +1,3 @@
-import { Pool } from "pg";
-import { drizzle } from "drizzle-orm/node-postgres";
-
 import { users, endpoints, logs, leads } from "./schema";
 export type { InferSelectModel, InferInsertModel } from "drizzle-orm";
 
@@ -15,11 +12,3 @@ export type NewLog = import("drizzle-orm").InferInsertModel<typeof logs>;
 
 export type Lead = import("drizzle-orm").InferSelectModel<typeof leads>;
 export type NewLead = import("drizzle-orm").InferInsertModel<typeof leads>;
-
-// Usa DATABASE_URL local, sin SSL
-const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  ssl: false,
-});
-
-export const db = drizzle(pool);


### PR DESCRIPTION
## Summary
- remove runtime db setup from `lib/db/index.ts`, keeping only type exports
- expose server-only runtime connection via `lib/db.ts`
- update imports to pull types from `lib/db/index`

## Testing
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68b4ff52af248325b4cd155408556ee5