### PR TITLE
Guard enum migrations against duplicate values

### DIFF
--- a/lib/db/drizzle/0001_normal_rhodey.sql
+++ b/lib/db/drizzle/0001_normal_rhodey.sql
@@ -1,2 +1,11 @@
-ALTER TYPE "logPostType" ADD VALUE 'webhook';--> statement-breakpoint
-ALTER TYPE "logPostType" ADD VALUE 'email';
+DO $$ BEGIN
+    ALTER TYPE "logPostType" ADD VALUE 'webhook';
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+    ALTER TYPE "logPostType" ADD VALUE 'email';
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END $$;


### PR DESCRIPTION
## Summary
- wrap enum ALTER TYPE statements with DO $$ ... EXCEPTION WHEN duplicate_object blocks to make migrations idempotent

## Testing
- `pnpm lint` *(fails: unknown ESLint options)*
- `pnpm test:unit` *(fails: exit code 130 after manual interruption; tests passing before interruption)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ff55775083259a31af0cf0d751a1