### PR TITLE
refactor: update db and action imports

### DIFF
--- a/app/actions/dashboard.ts
+++ b/app/actions/dashboard.ts
@@ -3,7 +3,7 @@
 
 import { sql } from 'drizzle-orm'
 import { db } from '@/lib/db'
-import { authenticatedAction } from '@/lib/data/safe-action'
+import { authenticatedAction } from '@/lib/data/safe-action.server'
 
 
 /**

--- a/app/actions/endpoints.ts
+++ b/app/actions/endpoints.ts
@@ -1,12 +1,12 @@
 'use server'
 
 import { revalidatePath } from "next/cache";
-import { db } from "../db";
-import type { Endpoint } from "../db/index";
-import { endpoints } from "../db/schema";
+import { db } from "@/lib/db";
+import type { Endpoint } from "@/lib/db";
+import { endpoints } from "@/lib/db/schema";
 import { eq, desc, and } from "drizzle-orm";
 import { getErrorMessage } from "@/lib/helpers/error-message";
-import { authenticatedAction } from "./safe-action";
+import { authenticatedAction } from "@/lib/data/safe-action.server";
 import { z } from "zod";
 import {
   createEndpointFormSchema,

--- a/app/actions/leads.ts
+++ b/app/actions/leads.ts
@@ -5,7 +5,7 @@ import { leads, endpoints } from '@/lib/db/schema'
 import { eq, desc, and } from 'drizzle-orm'
 import { revalidatePath } from 'next/cache'
 import { db } from '@/lib/db'
-import { authenticatedAction } from '@/lib/data/safe-action'
+import { authenticatedAction } from '@/lib/data/safe-action.server'
 import { z } from 'zod'
 
 /**

--- a/app/actions/logs.ts
+++ b/app/actions/logs.ts
@@ -4,7 +4,7 @@ import { logs, endpoints } from '@/lib/db/schema'
 import { eq, desc } from 'drizzle-orm'
 import { revalidatePath } from 'next/cache'
 import { db } from '@/lib/db'
-import { authenticatedAction } from '@/lib/data/safe-action'
+import { authenticatedAction } from '@/lib/data/safe-action.server'
 import { z } from 'zod'
 
 /**

--- a/app/actions/stripe.ts
+++ b/app/actions/stripe.ts
@@ -2,7 +2,7 @@
 
 import { Stripe } from 'stripe'
 import { headers } from 'next/headers'
-import { authenticatedAction } from '@/lib/data/safe-action'
+import { authenticatedAction } from '@/lib/data/safe-action.server'
 import { z } from 'zod'
 import { db } from '@/lib/db'
 import { users } from '@/lib/db/schema'

--- a/app/actions/users.ts
+++ b/app/actions/users.ts
@@ -3,7 +3,7 @@
 import { db } from '@/lib/db'
 import { users, endpoints } from '@/lib/db/schema'
 import { eq, sql } from 'drizzle-orm'
-import { authenticatedAction } from '@/lib/data/safe-action'
+import { authenticatedAction } from '@/lib/data/safe-action.server'
 
 /**
  * Increments the lead count for a user

--- a/lib/auth/index.ts
+++ b/lib/auth/index.ts
@@ -1,7 +1,7 @@
 import 'server-only';
 import NextAuth from "next-auth";
 import { DrizzleAdapter } from "@auth/drizzle-adapter";
-import { db } from "../db";
+import { db } from "@/lib/db";
 import type { NextAuthConfig } from "next-auth";
 import { User } from "next-auth";
 import Resend from "next-auth/providers/resend";


### PR DESCRIPTION
## Summary
- replace relative db imports with `@/lib/db`
- use server-only `authenticatedAction` wrapper in all actions

## Testing
- `pnpm test:unit --run`
- `pnpm run build` *(fails: Failed to fetch font `Inter`)*
- `pnpm lint` *(fails: Invalid Options: Unknown options: useEslintrc, extensions, resolvePluginsRelativeTo, rulePaths, ignorePath, reportUnusedDisableDirectives)*

------
https://chatgpt.com/codex/tasks/task_e_68b509e67b9883259d395b2c26f2d9f0