### PR TITLE
fix: specify safe-action import targets

### DIFF
--- a/app/actions/dashboard.ts
+++ b/app/actions/dashboard.ts
@@ -3,7 +3,7 @@
 
 import { sql } from 'drizzle-orm'
 import { db } from '@/lib/db'
-import { authenticatedAction } from '@/lib/data/safe-action'
+import { authenticatedAction } from '@/lib/data/safe-action.server'
 
 
 /**

--- a/app/actions/endpoints.ts
+++ b/app/actions/endpoints.ts
@@ -6,7 +6,7 @@ import type { Endpoint } from "../db/index";
 import { endpoints } from "../db/schema";
 import { eq, desc, and } from "drizzle-orm";
 import { getErrorMessage } from "@/lib/helpers/error-message";
-import { authenticatedAction } from "./safe-action";
+import { authenticatedAction } from "@/lib/data/safe-action.server";
 import { z } from "zod";
 import {
   createEndpointFormSchema,

--- a/app/actions/leads.ts
+++ b/app/actions/leads.ts
@@ -5,7 +5,7 @@ import { leads, endpoints } from '@/lib/db/schema'
 import { eq, desc, and } from 'drizzle-orm'
 import { revalidatePath } from 'next/cache'
 import { db } from '@/lib/db'
-import { authenticatedAction } from '@/lib/data/safe-action'
+import { authenticatedAction } from '@/lib/data/safe-action.server'
 import { z } from 'zod'
 
 /**

--- a/app/actions/logs.ts
+++ b/app/actions/logs.ts
@@ -4,7 +4,7 @@ import { logs, endpoints } from '@/lib/db/schema'
 import { eq, desc } from 'drizzle-orm'
 import { revalidatePath } from 'next/cache'
 import { db } from '@/lib/db'
-import { authenticatedAction } from '@/lib/data/safe-action'
+import { authenticatedAction } from '@/lib/data/safe-action.server'
 import { z } from 'zod'
 
 /**

--- a/app/actions/stripe.ts
+++ b/app/actions/stripe.ts
@@ -2,7 +2,7 @@
 
 import { Stripe } from 'stripe'
 import { headers } from 'next/headers'
-import { authenticatedAction } from '@/lib/data/safe-action'
+import { authenticatedAction } from '@/lib/data/safe-action.server'
 import { z } from 'zod'
 import { db } from '@/lib/db'
 import { users } from '@/lib/db/schema'

--- a/app/actions/users.ts
+++ b/app/actions/users.ts
@@ -3,7 +3,7 @@
 import { db } from '@/lib/db'
 import { users, endpoints } from '@/lib/db/schema'
 import { eq, sql } from 'drizzle-orm'
-import { authenticatedAction } from '@/lib/data/safe-action'
+import { authenticatedAction } from '@/lib/data/safe-action.server'
 
 /**
  * Increments the lead count for a user

--- a/components/groups/endpoints/create-form.tsx
+++ b/components/groups/endpoints/create-form.tsx
@@ -38,7 +38,7 @@ import {
 } from "@/components/ui/select";
 
 import { useAction } from "next-safe-action/hooks";
-import { parseActionError } from "@/lib/data/safe-action";
+import { parseActionError } from "@/lib/data/safe-action.client";
 import { createEndpoint } from "@/app/actions/endpoints";
 
 type DomainValues = z.infer<typeof formSchema>;

--- a/components/groups/endpoints/edit-form.tsx
+++ b/components/groups/endpoints/edit-form.tsx
@@ -38,7 +38,7 @@ import {
 import type { Endpoint } from "@/lib/db/index";
 
 import { useAction } from "next-safe-action/hooks";
-import { parseActionError } from "@/lib/data/safe-action";
+import { parseActionError } from "@/lib/data/safe-action.client";
 import { updateEndpoint } from "@/app/actions/endpoints";
 
 type DomainValues = z.infer<typeof formSchema>;


### PR DESCRIPTION
## Summary
- use client-specific safe action helper for endpoint forms
- import server-only safe action client in server actions

## Testing
- `pnpm lint` *(fails: Unknown options: useEslintrc, extensions, resolvePluginsRelativeTo, rulePaths, ignorePath, reportUnusedDisableDirectives)*
- `pnpm vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68b509e3c25083259c898066cd51a9f3